### PR TITLE
Add a new ASP for reference data services

### DIFF
--- a/asp.tf
+++ b/asp.tf
@@ -27,7 +27,7 @@ module "asp" {
   resource_group_name = "${azurerm_resource_group.rg.name}"
   asp_capacity        = "${local.asp_capacity}"
   asp_sku_size        = "${local.sku_size}"
-  asp_name            = "rpa-ref-data"
+  asp_name            = "${var.product}-rd"
   ase_name            = "${local.ase_name}"
   tag_list            = "${local.tags}"
 }

--- a/asp.tf
+++ b/asp.tf
@@ -20,14 +20,14 @@ module "asp" {
   tag_list            = "${local.tags}"
 }
 
-module "asp" {
+module "asp-rd" {
   source              = "git@github.com:hmcts/cnp-module-app-service-plan?ref=master"
   location            = "${var.location}"
   env                 = "${var.env}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   asp_capacity        = "${local.asp_capacity}"
   asp_sku_size        = "${local.sku_size}"
-  asp_name            = "${var.product}-rd"
+  asp_name            = "rpa-ref-data"
   ase_name            = "${local.ase_name}"
   tag_list            = "${local.tags}"
 }

--- a/asp.tf
+++ b/asp.tf
@@ -19,3 +19,15 @@ module "asp" {
   ase_name            = "${local.ase_name}"
   tag_list            = "${local.tags}"
 }
+
+module "asp" {
+  source              = "git@github.com:hmcts/cnp-module-app-service-plan?ref=master"
+  location            = "${var.location}"
+  env                 = "${var.env}"
+  resource_group_name = "${azurerm_resource_group.rg.name}"
+  asp_capacity        = "${local.asp_capacity}"
+  asp_sku_size        = "${local.sku_size}"
+  asp_name            = "rpa-ref-data"
+  ase_name            = "${local.ase_name}"
+  tag_list            = "${local.tags}"
+}


### PR DESCRIPTION
Add a new ASP so that the reference data services don't interfere with other Reform apps on the default RPA shared ASP