### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/application-insights.tf
+++ b/application-insights.tf
@@ -1,27 +1,35 @@
 
 // Need to create new AppInsights in the UK South region only, as per the requirement.
 
-resource "azurerm_application_insights" "em_appinsights" {
-  name                = "em-${var.env}"
-  location            = var.location
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env     = var.env
+  product = var.product
+  name    = "em"
+
   resource_group_name = azurerm_resource_group.rg.name
-  application_type    = var.application_type
-  tags                = local.tags
+
+  common_tags = local.tags
 }
 
+moved {
+  from = azurerm_application_insights.em_appinsights
+  to   = module.application_insights.azurerm_application_insights.this
+}
 resource "azurerm_key_vault_secret" "em_app_insights_connection_string" {
   name         = "em-app-insights-connection-string"
-  value        = azurerm_application_insights.em_appinsights.connection_string
+  value        = module.application_insights.connection_string
   key_vault_id = module.key_vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "em_app_insights_key" {
   name         = "EmAppInsightsInstrumentationKey"
-  value        = azurerm_application_insights.em_appinsights.instrumentation_key
+  value        = module.application_insights.instrumentation_key
   key_vault_id = module.key_vault.key_vault_id
 }
 
 output "em_appInsightsInstrumentationKey" {
   sensitive = true
-  value = azurerm_application_insights.em_appinsights.instrumentation_key
+  value     = module.application_insights.instrumentation_key
 }


### PR DESCRIPTION
Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

Change description
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.