### PR TITLE
Remove helm-requirements from renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,12 +3,7 @@
   "extends": [
     "local>hmcts/.github:renovate-config"
   ],
-  "labels": ["dependencies"],
-  "helm-requirements":
-  {
-    "fileMatch": ["\\Chart.yaml|requirements.yaml$"],
-    "aliases": {
-      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
-    }
-  }
+  "labels": [
+    "dependencies"
+  ]
 }

--- a/.github/renovate.json.bak
+++ b/.github/renovate.json.bak
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>hmcts/.github:renovate-config"
+  ],
+  "labels": ["dependencies"],
+  "helm-requirements":
+  {
+    "fileMatch": ["\\Chart.yaml|requirements.yaml$"],
+    "aliases": {
+      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
+    }
+  }
+}


### PR DESCRIPTION
This PR removes the deprecated helm-requirements manager which is no longer needed. Please review and merge.